### PR TITLE
Xtract-DB formatting edits

### DIFF
--- a/afs/index.rst
+++ b/afs/index.rst
@@ -199,28 +199,26 @@ Fill out the following fields and click **Create**:
 
   .. figure:: https://s3.amazonaws.com/s3.nutanixworkshops.com/ts18/afs/23.png
 
-In **Prism > VM**, click **+ Create VM** and fill out the following fields:
+In **Prism > VM > Table**, click **+ Create VM**.
+
+Fill out the following fields and click **Save**:
 
 - **Name** - NFS-Client
 - **Description** - CentOS VM for testing AFS NFS export
-- **vCPU** - 2
+- **vCPU(s)** - 2
 - **Number of Cores per vCPU** - 1
-- **Memory** - 4
+- **Memory** - 4 GiB
+- Select **+ Add New Disk**
 
-Click **+ Add New Disk**, fill out the following fields, and click **Add**:
+  - **Operation** - Clone from Image Service
+  - **Image** - CentOS
+  - Select **Add**
+- Select **Add New NIC**
 
-- **Type** - DISK
-- **Operation** - Clone from Image Service
-- **Bus Type** - SCSI
-- **Image** - *<CentOS Disk Image>*
+  - **VLAN Name** - Secondary
+  - Select **Add**
 
-Click **Add New NIC**. fill out the following fields, and click **Add**:
-
-- **VLAN Name** - Secondary
-
-Click **Save**.
-
-In **Prism > VM > Table**, select the **NFS-Client** VM and click **Power on**.
+Select the **NFS-Client** VM and click **Power on**.
 
 Once the VM has started, click **Launch Console** and log in as **root** or connect via SSH.
 

--- a/citrix/index.rst
+++ b/citrix/index.rst
@@ -115,32 +115,26 @@ Creating the Gold Image
 Creating the VM
 ...............
 
-In **Prism > VM**, click **+ Create VM** and fill out the following fields:
+In **Prism > VM > Table**, click **+ Create VM**.
 
-  - **Name** - W10-Gold
-  - **Description** - Windows 10 x64 XenDesktop Gold Image
-  - **vCPU** - 2
-  - **Number of Cores per vCPU** - 1
-  - **Memory** - 4
+Fill out the following fields and click **Save**:
 
-  .. figure:: https://s3.amazonaws.com/s3.nutanixworkshops.com/vdi_ahv/lab4/1.png
+- **Name** - W10-Gold
+- **Description** - Windows 10 x64 XenDesktop Gold Image
+- **vCPU(s)** - 2
+- **Number of Cores per vCPU** - 1
+- **Memory** - 4 GiB
+- Select **+ Add New Disk**
 
-Click **+ Add New Disk**, fill out the following fields, and click **Add**:
-
-  - **Type** - DISK
   - **Operation** - Clone from Image Service
-  - **Bus Type** - SCSI
-  - **Image** - *<Windows 10 Disk Image>*
-
-  .. figure:: https://s3.amazonaws.com/s3.nutanixworkshops.com/vdi_ahv/lab4/2.png
-
-Click **Add New NIC**. fill out the following fields, and click **Add**:
+  - **Image** - Windows10
+  - Select **Add**
+- Select **Add New NIC**
 
   - **VLAN Name** - Secondary
+  - Select **Add**
 
-Click **Save**.
-
-In **Prism > VM > Table**, select the **W10-Gold** VM and click **Power on**.
+Select the **W10-Gold** VM and click **Power on**.
 
 Once the VM has started, click **Launch Console**.
 

--- a/example/index.rst
+++ b/example/index.rst
@@ -1,3 +1,4 @@
+.. Adding labels to the beginning of your lab is helpful for linking to the lab from other pages
 .. _example_lab:
 
 -----------
@@ -9,10 +10,10 @@ Overview
 
 Here is where we provide a high level description of what the user will be doing during this module. We want to frame why this content is relevant to an SE/Services Consultant and what we expect them to understand after completing the lab.
 
-Text and Figures
-++++++++++++++++
+Using Text and Figures
+++++++++++++++++++++++
 
-Label sections appropriately, see existing labs if further guidance is required. Use consistent markup for titles, subtitles, sub-subtitles, etc. The markup in the example can serve as a guide but other characters can be used within a given workshop, as long as they are consistent. Other than lab titles (that need to follow a certain linear progression) avoid numbering steps.
+Label sections appropriately, see existing labs if further guidance is required. Section titles should begin with present tense verbs to queue what is being done in each section. Use consistent markup for titles, subtitles, sub-subtitles, etc. The markup in the example can serve as a guide but other characters can be used within a given workshop, as long as they are consistent. Other than lab titles (that need to follow a certain linear progression) avoid numbering steps.
 
 Below are examples of standards we should strive to maintain in writing lab guides. *Italics* is used to indicate when information of values external to the lab guide are referenced. **Bold** is used to reference words and phrases in the UI. **Bold** should also be used to highlight the key name in lists containing key/value pairs as shown below. The **>** character is used to show a reasonable progression of clicks, such as traversing a drop down menu. When appropriate, try to consolidate short, simple tasks. ``Literals`` should be used for file paths.
 
@@ -42,8 +43,8 @@ Select **Enable IP Address Management** and fill out the following fields:
 
 Click **Submit > Save**.
 
-Notes
-+++++
+Using Notes
++++++++++++
 
 Notes provide easily noticable interjections to lab instructions. Reasons to use a note include calling attention to a step that requires additional context or referencing external resources. Make sure to include a return before and after the note directive for it to render properly. **Please don't abuse notes.**
 
@@ -68,8 +69,8 @@ Click :fa:`eject` to unmount the disk image from the **CD-ROM** device.
 
 It is **not** necessary to include inline icons when the are accompanied by a label/text in the UI, such as :fa:`times` **Delete**
 
-Codeblocks
-++++++++++
+Using Codeblocks
+++++++++++++++++
 
 You can insert code into your lab guides both inline and via external files. Inline is a great option for providing command line instructions or display shorter code snippets.
 
@@ -111,6 +112,132 @@ Use the literalinclude directive to create a code block from an external file. T
      :name: literal-include-example
 
 .. note:: For proper color markup, specify the language of your code using one of the supported lexers found at `pygments.org <http://pygments.org/docs/lexers/>`_.
+
+Creating a VM
++++++++++++++
+
+Example markup for creating a VM in Prism Element:
+
+  In **Prism > VM > Table**, click **+ Create VM**.
+
+  Fill out the following fields and click **Save**:
+
+  - **Name** - Xtract-VM
+  - **Description** - Xtract for VMs
+  - **vCPU(s)** - 2
+  - **Number of Cores per vCPU** - 2
+  - **Memory** - 4 GiB
+  - Select **+ Add New Disk**
+
+    - **Operation** - Clone from Image Service
+    - **Image** - Xtract-VM
+    - Select **Add**
+  - Remove **CD-ROM** Disk
+  - Select **Add New NIC**
+
+    - **VLAN Name** - Primary
+    - **IP Address** - *10.21.XX.42*
+    - Select **Add**
+
+  Select the **Xtract-VM** VM and click **Power on**.
+
+  Once the VM has started, click **Launch Console**.
+
+Example markup for creating a VM in Prism Central:
+
+  In **Prism Central > Explore > VMs**, click **Create VM**.
+
+  Fill out the following fields and click **Save**:
+
+  - **Name** - Xtract-VM
+  - **Description** - Xtract for VMs
+  - **vCPU(s)** - 2
+  - **Number of Cores per vCPU** - 2
+  - **Memory** - 4 GiB
+  - Select **+ Add New Disk**
+
+    - **Operation** - Clone from Image Service
+    - **Image** - Xtract-VM
+    - Select **Add**
+  - Remove **CD-ROM** Disk
+  - Select **Add New NIC**
+
+    - **VLAN Name** - Primary
+    - **IP Address** - *10.21.XX.42*
+    - Select **Add**
+
+  Select the **Xtract-VM** VM and click **Actions > Power on**.
+
+  Once the VM has started, click **Actions > Launch console**.
+
+Example markup for creating a Service in Calm:
+
+  In **Application Overview > Services**, click :fa:`plus-circle`.
+
+  Note **Service1** appears in the **Workspace** and the **Configuration Pane** reflects the configuration of the selected Service. You can rearrange the Service icons on the Workspace by clicking and dragging them.
+
+  Fill out the following fields:
+
+  - **Service Name** - APACHE_PHP
+  - **Name** - APACHE_PHP_AHV
+  - **Cloud** - Nutanix
+  - **OS** - Linux
+  - **VM Name** - APACHE_PHP
+  - **Image** - CentOS
+  - **Device Type** - Disk
+  - **Device Bus** - SCSI
+  - Select **Bootable**
+  - **vCPUs** - 2
+  - **Cores per vCPU** - 1
+  - **Memory (GiB)** - 4
+  - Select :fa:`plus-circle` under **Network Adapters (NICs)**
+  - **NIC** - Secondary
+  - **Crendential** - CENTOS
+
+  Scroll to the top of the **Configuration Panel**, click **Package**.
+
+  Fill out the following fields:
+
+  - **Name** - APACHE_PHP_PACKAGE
+  - **Install Script Type** - Shell
+  - **Credential** - CENTOS
+
+  Copy and paste the following script into the **Install Script** field:
+
+  .. code-block:: bash
+
+     #!/bin/bash
+     set -ex
+     # -*- Install httpd and php
+     sudo yum update -y
+     sudo yum -y install epel-release
+     sudo rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm
+     sudo yum install -y httpd php56w php56w-mysql
+
+     echo "<IfModule mod_dir.c>
+             DirectoryIndex index.php index.html index.cgi index.pl index.php index.xhtml index.htm
+     </IfModule>" | sudo tee /etc/httpd/conf.modules.d/dir.conf
+
+     echo "<?php
+     phpinfo();
+     ?>" | sudo tee /var/www/html/info.php
+     sudo systemctl restart httpd
+     sudo systemctl enable httpd
+
+  Fill out the following fields:
+
+  - **Uninstall Script Type** - Shell
+  - **Credential** - CENTOS
+
+  Copy and paste the following script into the **Uninstall Script** field:
+
+  .. code-block:: bash
+
+    #!/bin/bash
+    echo "Goodbye!"
+
+  Click **Save**.
+
 
 Takeaways
 +++++++++

--- a/hycu/index.rst
+++ b/hycu/index.rst
@@ -214,27 +214,26 @@ Select the **Exclude** policy and click **Set Default > Yes**.
 Backing Up A VM
 +++++++++++++++
 
-In **Prism > VM**, click **+ Create VM** and fill out the following fields:
+In **Prism > VM > Table**, click **+ Create VM**.
 
-  - **Name** - WS12-BackupTest
-  - **vCPU** - 2
-  - **Number of Cores per vCPU** - 1
-  - **Memory** - 4
+Fill out the following fields and click **Save**:
 
-Click **+ Add New Disk**, fill out the following fields, and click **Add**:
+- **Name** - WS12-BackupTest
+- **Description** - WS12-BackupTest
+- **vCPU(s)** - 2
+- **Number of Cores per vCPU** - 1
+- **Memory** - 4 GiB
+- Select **+ Add New Disk**
 
-  - **Type** - DISK
   - **Operation** - Clone from Image Service
-  - **Bus Type** - SCSI
-  - **Image** - *Windows Server 2012 Disk Image*
-
-Click **Add New NIC**. fill out the following fields, and click **Add**:
+  - **Image** - Windows2012
+  - Select **Add**
+- Select **Add New NIC**
 
   - **VLAN Name** - Primary
+  - Select **Add**
 
-Click **Save**.
-
-In **Prism > VM > Table**, select the **WS12-BackupTest** VM and click **Power on**.
+Select the **WS12-BackupTest** VM and click **Power on**.
 
 Once the VM has started, click **Launch Console**.
 

--- a/xtract-db/xtract-db.rst
+++ b/xtract-db/xtract-db.rst
@@ -26,7 +26,7 @@ Getting Engaged with the Product Team
 Deploying Xtract for DBs
 ++++++++++++++++++++++++
 
-In **Prism > VM > Table**, click **+ Create VM**.
+In **Prism Central > Explore > VMs**, click **Create VM**.
 
 Fill out the following fields and click **Save**:
 
@@ -46,7 +46,7 @@ Fill out the following fields and click **Save**:
   - **IP Address** - *10.21.XX.43*
   - Select **Add**
 
-Select the **Xtract-DB** VM and click **Power On**.
+Select the **Xtract-VM** VM and click **Actions > Power on**.
 
 Open \https://<*XTRACT-DB-VM-IP*>/ in a browser to access **Xtract for DBs**.
 
@@ -137,7 +137,7 @@ Preparing Target Template
 
 In order to migrate the database we need to create a master VM on the target cluster to which the database can be migrated. Xtract can use a single template VM on the target cluster to deploy VMs for multiple projects/instances.
 
-In **Prism > VM > Table**, click **+ Create VM**.
+In **Prism Central > Explore > VMs**, click **Create VM**.
 
 Fill out the following fields and click **Save**:
 
@@ -156,7 +156,7 @@ Fill out the following fields and click **Save**:
   - **VLAN Name** - Primary
   - Select **Add**
 
-Select the **Xtract-DB-2012r2-Master** VM and click **Power On**.
+Select the **Xtract-VM** VM and click **Actions > Power on**.
 
 Once the VM has started, click **Launch Console**.
 

--- a/xtract-db/xtract-db.rst
+++ b/xtract-db/xtract-db.rst
@@ -1,19 +1,19 @@
 .. _xtractdb_lab:
 
--------------------
+--------------------
 Xtract for Databases
--------------------
+--------------------
 
 Overview
 ++++++++
 
 .. note::
 
-  This lab should be completed **AFTER** the :ref:`ssp` lab.
+  This lab should be completed **AFTER** the :ref:`ssp_lab` lab.
 
-  Estimated time to complete: **1 HOUR**
+  Estimated time to complete: **90 MINUTES**
 
-In this exercise you will deploy, and use the Xtract tool to migrate a Database.
+In this exercise you will deploy Xtract for DBs and migrate a MS SQL 2014 database from ESXi to AHV. Rather than migrating the entire VM, migrating the database instance allows for streamlined automation of Best Practice configuration.
 
 Getting Engaged with the Product Team
 .....................................
@@ -23,51 +23,51 @@ Getting Engaged with the Product Team
 - **Product Marketing Manager** - Marc Trouard-Riolle, marc.trouardriolle@nutanix.com
 - **Technical Marketing Engineer** - Mike McGhee, michael.mcghee@nutanix.com
 
-Deploy Xtract for DB
-+++++++++++++++++
+Deploying Xtract for DBs
+++++++++++++++++++++++++
 
-In **Prism Central > Explore*, click **VMs**.
-
-  .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb01.png
-
-Click **Create VM**.
+In **Prism > VM > Table**, click **+ Create VM**.
 
 Fill out the following fields and click **Save**:
 
 - **Name** - Xtract-DB
 - **Description** - Xtract for DBs
-- **VCPU(S)** - 2
-- **Cores** - 1
-- **Memory** - 4GiB
-- **Disks** - **+ Add New Disk**
-- **Disk Image (From Image Service)** - Xtract-DB
-- **Network** - Primary
-- **IP Address** - 10.21.XX.43
+- **vCPU(s)** - 2
+- **Number of Cores per vCPU** - 1
+- **Memory** - 4 GiB
+- Select **+ Add New Disk**
 
-Now Power on the **Xtract-DB** VM.
+  - **Operation** - Clone from Image Service
+  - **Image** - Xtract-DB
+  - Select **Add**
+- Select **Add New NIC**
 
-When it completes, open a browser window to the **Xtract for DBs** Dashboard, https://10.21.XX.43
+  - **VLAN Name** - Primary
+  - **IP Address** - *10.21.XX.43*
+  - Select **Add**
 
-Login with the following credentials:
+Select the **Xtract-DB** VM and click **Power On**.
+
+Open \https://<*XTRACT-DB-VM-IP*>/ in a browser to access **Xtract for DBs**.
+
+Log in with the following credentials:
 
 - **Username** - nutanix
 - **Password** - nutanix/4u
 
- Fill in **Name**, **Company**, and **Job Title**, then **Accept** the EULA.
+Fill in **Name**, **Company**, and **Job Title**, then **Accept** the EULA.
 
-  .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb02.png
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb02.png
 
-Click **OK** on the **Nutanix Customer Experience Program** pop-up.
+Click **OK** when prompted about the **Nutanix Customer Experience Program**.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb03.png
 
-Create Project & Migrate Database with Xtract for DBs
-+++++++++++++
+Migrating a Database
+++++++++++++++++++++
 
-In this portion of the lab we will create a new project in **Xtract-DB**, and migrate a MS SQL Server database.
-
-Create New Migration Project
-.................
+Creating a Migration Project
+............................
 
 Enter project name, and click **Create New Project**:
 
@@ -78,39 +78,39 @@ Enter project name, and click **Create New Project**:
 Fill out the following fields and click **Begin Scan**:
 
 - **Scan Name** - Parts DB
-- **HOSTNAME (OR IP ADDRESS)** - *IP of SQLSvrTeam-XX*
-- **Instance Name (Or Port)** - 1433
-- **Username** - ``NTNXLAB\Administrator``
+- **Hostname (or IP Address)** - *<SQLSvrTeam-XX IP Address>*
+- **Instance Name (or Port)** - 1433
+- **Username** - NTNXLAB\\Administrator
 - **Password** - nutanix/4u
 
-If/When the scan fails, you will need uplift the permissions of the scan User.
+If the Scan fails, you will need elevate the permissions of the Scan User.
 
 Click the **Actions** dropdown, and select **Elevate Scan User Privileges**.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb06.png
 
-Fill out the following fields and click **Re-Scan**:
+Fill out the following fields and click **Re-scan**:
 
 - **Username** - sa
 - **Password** - nutanix/4u
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb07.png
 
-If/When the **XP Command Shell** pop-up displays, fill out the following fields and click **Done**;
+If prompted to setup the **XP Command Shell (xp_cmdshell) Proxy User**, fill out the following fields and click **Done**:
 
 - **Username** - sa
 - **Password** - nutanix/4u
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb36.png
 
-After the scan completes successfully, you will see the overview page.
+After the scan completes successfully, select your **MSSQLSERVER** Instance to see the Overview.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb08.png
 
-Generate Nutanix Best Practices Design
-.................
+Generating a Design
+...................
 
-Click **Generate Design**.
+Select your **MSSQLSERVER** Instance and click **Generate Design**.
 
 Click the :fa:`pencil` to change the Design name.
 
@@ -122,75 +122,89 @@ Fill out the following fields and click **Save**:
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb10.png
 
-Click **MSSQLSERVER-UPTICK-WebsiteDB**, and you will see the design Details.
+Click **MSSQLSERVER-UPTICK-WebsiteDB** to review the Design Details.
 
-  .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb11.png
+.. note::
 
-Click **< Back** to go back to the **Design Templates** view.
+  Alternating the **Target Hypervisor** you can see part of Xtract's Best Practices automation in action. When ESXi is selected the disks are appropriately spread across multiple PVSCSI controllers.
 
-Prepare **Xtract Master** VM
-.................
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb11.png
 
-In **Prism > VM**, click **VM**, then click **Table**.
+Click **< Back** to return to the **Design Templates** view.
 
-Click **+ Create VM**.
+Preparing Target Template
+.........................
+
+In order to migrate the database we need to create a master VM on the target cluster to which the database can be migrated. Xtract can use a single template VM on the target cluster to deploy VMs for multiple projects/instances.
+
+In **Prism > VM > Table**, click **+ Create VM**.
 
 Fill out the following fields and click **Save**:
 
 - **Name** - Xtract-DB-2012r2-Master
 - **Description** - Xtract-DB win2012r2 Master VM
-- **VCPU(S)** - 2
-- **Cores** - 1
-- **Memory** - 8GiB
-- **Disks** - **+ Add New Disk**
-- **Disk Image (From Image Service)** - Windows2012
-- **Network** - Primary
+- **vCPU(s)** - 2
+- **Number of Cores per vCPU** - 1
+- **Memory** - 8 GiB
+- Select **+ Add New Disk**
 
-Now Power on the **Xtract-DB-2012r2-Master** VM.
+  - **Operation** - Clone from Image Service
+  - **Image** - Windows2012
+  - Select **Add**
+- Select **Add New NIC**
 
-Launch Console session to **Xtract-DB-2012r2-Master** VM.
+  - **VLAN Name** - Primary
+  - Select **Add**
 
-Set password to **nutanix/4u**.
+Select the **Xtract-DB-2012r2-Master** VM and click **Power On**.
 
-Install Nutanix Guest Tools, and Restart.
+Once the VM has started, click **Launch Console**.
 
-Disable the Windows Firewall Service
+Set the local Administrator password to **nutanix/4u**.
 
-Log in and run Windows Update to get the latest updates, and Restart.
+In **Prism > VM > Table**, select **Xtract-DB-2012r2-Master** and click **Manage Guest Tools**.
 
-  .. Note:: You need update KB2919355 for MSSQLServer to install correctly
+Select **Enable Nutanix Guest Tools** and **Mount Nutanix Guest Tools**, and click **Submit**.
 
-Now turn off Windows Update
+Install Nutanix Guest Tools and restart the VM.
 
-shutdown the VM.
+Log in and run Windows Update. Set Windows Updates to **Check for updates but let me choose whether to download and install them**. Restart the VM after updates have finished installing.
 
-Makes sure the **MS SQL Server 2016 ISO** is in **Image Service**.
+.. note::
 
-  .. Note:: For DHCP based Target VM, use non SysPrepped Template. For Static IP based Target VM, put template in a SysPrepped state.
+  Microsoft SQL Server 2016 requires `KB2919355 <https://www.microsoft.com/en-us/download/details.aspx?id=42334>`_ to install correctly.
 
-Deploy new Database VM
-.................
+Disable the Windows Firewall Service.
 
-In Xtract for DBs, click **Proceed to Deploy**.
+Shutdown the VM.
+
+.. note:: It is not necessary to sysprep the target template VM if the target VM will use DHCP to obtain an IP address. For a migration requiring a static IP address, the target template VM must be put in a sysprep state prior to deployment.
+
+Verify the **SQL Server 2016** installation media is available in the **Image Service** of your target cluster.
+
+Deploying Target VM
+...................
+
+In **Xtract for DBs**, click **Proceed to Deploy**.
 
 Click **...** under **Actions**, and select **Deploy**.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb12.png
 
-Ensure you have all the Pre-Requisites, and click **Proceed to Deploy**.
+Note the prerequisites and click **Proceed to Deploy**.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb13.png
 
- Fill out the following fields for **Prism Credentials**, and click **Connect**:
+Fill out the following fields for **Prism Credentials**, and click **Connect**:
 
- - **IP Address** - 10.21.XX.37
- - **Port** - 9440
- - **Username** - xtract
- - **Password** - *Prism Password*
+- **IP Address** - *<Nutanix Cluster Virtual IP>*
+- **Port** - 9440
+- **Username** - admin
+- **Password** - *<Nutanix admin Password>*
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb14.png
 
-After Hypervisor connection is made, click **Configure VMs**.
+After successful connection to your target Nutanix cluster, click **Configure VMs**.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb15.png
 
@@ -200,9 +214,13 @@ Fill out the following fields and click **Next**:
 - **Container Name** - Databases
 - **Retain clone of master VM on the Container** - Unselected
 - **Network** - Primary
-- **DHCP** - Selected
+- Select **DHCP**
 
-  .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb16.png
+.. note::
+
+  If existing storage containers exist on the target Nutanix cluster that match the specifications from the Best Practices design, they will be available to select from the **Container Name** field.
+
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb16.png
 
 Fill out the following fields and click **Next**:
 
@@ -211,21 +229,23 @@ Fill out the following fields and click **Next**:
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb17.png
 
-Fill out the following fields and click **Review**:
+Download the `SQL Server 2016 KB3210089 Service Pack <http://10.21.64.50/images/SQLServer2016-KB3210089-x64.exe>`_.
+
+Fill out the following fields:
 
 - **SQL Server Image** - MMSSQL-2016SP1-ISO
-- **Service Pack (Optional)** - ``http://10.21.64.50/images/SQLServer2016-KB3210089-x64.exe``
-
-  .. Note:: You will need to download SQLServer2016 Service Pack before you can upload.
+- **Service Pack (Optional)** - SQLServer2016-KB3210089-x64.exe
+- Select **Upload**
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb18.png
 
-Select **Enter Account Credentials**
+Click **Enter Account Credentials**.
 
 Fill out the following fields and click **Next**:
 
 - **Domain Account Name** - ``ntnxlab\adminuser01``
 - **Password** - nutanix/4u
+
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb38.png
 
@@ -237,13 +257,15 @@ Fill out the following fields and click **Validate and Save**:
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb37.png
 
-Disregard any errors about connecting to the domain.
+Click **Review**.
 
-Ensure everything is correct, and click **Deploy**.
+.. note:: You can safely ignore any errors regarding the failure to verify the domain credentials.
+
+Review your configuration and click **Deploy**.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb19.png
 
-You will see the status of deployment.
+Monitor the status of your deployment. Select **# task(s) completed** and **# pending task(s)** to see a complete list of pending and completed tasks.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb20.png
 
@@ -251,71 +273,70 @@ Once complete, click **Proceed to Migrate**.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb21.png
 
-Migrate Database
-.................
+Migrating the Database
+......................
 
-Click **Create a Migration Plan**
+Click **Create a Migration Plan**.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb22.png
 
-Click the :fa:`pencil` to update the Plan names.
+Click :fa:`pencil` to update the **New Sample Plan** Name.
 
 - **Plan Name** - UptickDB Plan.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb23.png
 
-Click the :fa:`plus-circle` to select **MSSQLSERVER\MSSQLSERVER**, and click **Next**.
+Click :fa:`plus-circle` to select the **MSSQLSERVER** Instance, and click **Next**.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb24.png
 
-If/When it asks you for a File Share add the link to the share on the MSSQL Server, and click **Save and Start the Plan**.
+If prompted for a file share to store new Full and Transaction Log backups, use the following file share located on your source SQL Server VM, and click **Save and Start the Plan**.
 
-- **Server File Path** - ``\\SQLSvrTeam-XX\xdb``
-- **Server File Path Example** - ``\\10.21.64.54\xdb``
+- **Server File Path** - ``\\<SQLSvrTeam-XX-IP-Address>\xdb``
 
-.. Note::
+.. note::
 
-  This setup is for Tech Summit. In production this would normally not be on the same server as the Database.
+  As backup creation can be resource intensive, best practice for migration would be to have Xtract for DBs use a share on a dedicated filer, such as AFS. Creating the share on the source VM is done solely out of convenience for this exercise.
 
-  .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb25.png
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb25.png
 
-Click **Proceed** to launch the **Migration**.
+Click **Proceed** to begin the migration.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb26.png
 
-You may see a pop-up stating that the versions do not match, and it is proceeding (will use the service pack you uploaded).
+Ignore any warnings regarding SQL Server Version mismatch.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb27.png
 
- When you see the status change to **Ready for Cutover**, Click the **Action** dropdown and click **Cutover Databases**.
+When the **Status** changes to **Ready for Cutover**, click **Action > Cutover Databases**.
 
-  .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb28.png
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb28.png
 
- Click **Proceed** to launch the **Cutover**.
+Click **Proceed** to launch the **Cutover**.
 
-  .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb29.png
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb29.png
 
- You may see some pop-up messages like these, go ahead and close them.
+Ignore additional warning messages.
 
-  .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb30.png
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb30.png
 
- When you see the status change to **Ready for Re-Balancing**, Click the **Action** dropdown and click **Initiate Post Cutover Processing**.
+When the **Status** changes to **Ready for Re-balancing**, click **Action > Initiate Post Cutover Processing**.
 
-  .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb31.png
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb31.png
 
-Check **Re-Balance Data in Databases**, and click **Start**.
+Select **Re-balance Data in Databases** and click **Start**.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb32.png
 
- When you see the status change to **Ready for Final Processing**, Click the **Action** dropdown and click **Initiate Data Cleanup**.
+When the **Status** changes to **Ready for Final Processing**, click the **Action > Initiate Data Cleanup**.
 
-   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb33.png
+ .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb33.png
 
- Click **Proceed** to launch the **Cleanup**.
+Click **Proceed** to launch the **Cleanup**.
 
-  .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb34.png
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb34.png
 
-When everything is done, you will see status of **Completed**.
+After successful Cleanup, the **Status** will change to **Completed**.
 
   .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-db/xtractdb35.png
 
@@ -328,4 +349,6 @@ Takeaways
 
 - This approach enables businesses to migrate from any source platform (virtual, physical and public cloud) with ease, optimizing the database servers in the process and extracting maximum value from the Nutanix investment.
 
-- Xtract eliminates human error and data inconsistency in migrations
+- Xtract eliminates human error and data inconsistency in migrations.
+
+- Xtract optimizes database performance by automatically re-balancing data across database files during migration.

--- a/xtract-vm/xtract-vm.rst
+++ b/xtract-vm/xtract-vm.rst
@@ -26,7 +26,7 @@ Getting Engaged with the Product Team
 Deploying Xtract for VMs
 ++++++++++++++++++++++++
 
-In **Prism > VM > Table**, click **+ Create VM**.
+In **Prism Central > Explore > VMs**, click **Create VM**.
 
 Fill out the following fields and click **Save**:
 
@@ -52,7 +52,7 @@ Fill out the following fields and click **Save**:
 .. literalinclude:: xtract-vm-cloudinit-script
    :caption: Xtract-VM Custom Script
 
-Select the **Xtract-VM** VM and click **Power On**.
+Select the **Xtract-VM** VM and click **Actions > Power on**.
 
 Open \https://<*XTRACT-VM-IP*>/ in a browser to access the **Xtract for VMs** dashboard.
 

--- a/xtract-vm/xtract-vm.rst
+++ b/xtract-vm/xtract-vm.rst
@@ -9,7 +9,7 @@ Overview
 
 .. note::
 
-  This lab should be completed **AFTER** the :ref:`ssp` lab.
+  This lab should be completed **AFTER** the :ref:`ssp_lab` lab.
 
   Estimated time to complete: **1 HOUR**
 
@@ -26,11 +26,7 @@ Getting Engaged with the Product Team
 Deploying Xtract for VMs
 ++++++++++++++++++++++++
 
-In **Prism Central > Explore**, click **VMs**.
-
-  .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/xtract-vm/xtractvm01.png
-
-Click **Create VM**.
+In **Prism > VM > Table**, click **+ Create VM**.
 
 Fill out the following fields and click **Save**:
 


### PR DESCRIPTION
Some formatting and typo fixes. Updated section headers to present tense. Removed bold markup from section titles. Modified deployment steps slightly for Prism Element instead of Prism Central. Prism Element was already used later in the lab for the template VM deployment and if the lab has no dependencies on Prism Central it simplifies the lab.

Updated the time estimate as well based on my experience walking through the lab - maybe 90 minutes is too conservative. 75?