### PR TITLE
Karan/MSSQL formatting edits

### DIFF
--- a/calm_mssql/calm_mssql.rst
+++ b/calm_mssql/calm_mssql.rst
@@ -1,71 +1,67 @@
-***************************
-Calm Blueprint (MSSQL-2014)
-***************************
+.. _calm_mssql_lab:
 
-
-.. note:: IMPORTANT! This blueprint is for Lab purposes only. Do not put this into production without modifying it to meet your organizations requirements, Nutanix Best Practices, and Microsoft SQL Best Practices.
+***************************
+Calm Blueprint (MSSQL 2014)
+***************************
 
 Overview:
 *********
 
-.. note:: Estimated time to complete: **20 MINUTES**
+.. note::
 
-In this lab participants will walk through importing and deploying an MS Windows Server 2012 R2, and an instance of MS SQL Database - 2014.
+  This lab should be completed **AFTER** the :ref:`karan_lab` lab.
 
+  Estimated time to complete: **20 MINUTES**
+
+  **IMPORTANT!** This Blueprint is for test purposes only. Do not put this into production without modifying it to meet your organizations requirements, Nutanix Best Practices, and Microsoft SQL Best Practices.
+
+In this exercise you will use Calm to import and deploy a Blueprint that installs a Microsoft SQL Server 2014 Instance on a Windows Server 2012 R2 VM. This exercise serves as an example of the extensibility of Calm for automating and orchestrating Windows based applications.
 
 Getting Engaged with the Product Team
 =====================================
 - **Slack** - #calm
 - **Product Manager** - Jasnoor Gill, jasnoor.gill@nutanix.com
-- **Product Marketing Manager** - Gil Haberman, gil.haberman@nutanix.com
-- **Technical Marketing Engineer** - Chris Brown, christopher.brown@nutanix.com
+- **Product Marketing Manager** - Chris Brown, christopher.brown@nutanix.com
+- **Technical Marketing Engineer** - Brian Suhr, brian.suhr@nutanix.com
 - **Field Specialists** - Mark Lavi, mark.lavi@nutanix.com; Andy Schmid, andy.schmid@nutanix.com
 
-Prerequisites:
-**************
-Certain prerequisites must be met before installation will succeed. The following must be configured:
+Uploading the Blueprint
+***********************
+Download the provided :download:`MSSQL Blueprint<./blueprints/windowsMSSQL2014.json>`.
 
-- Karan Guest VM **MUST** be configured and Installed: karan-setup_
+From **Prism Central > Apps**, select |image1| **Blueprints** from the sidebar.
 
-
-Blueprint:
-***********
-Download the MSSQL Blueprint by clicking the link provided below:
-
-:download:`mssql2014.json <./blueprints/windowsMSSQL2014.json>`
-
-From Apps (Calm) within Prism Central, navigate to the Blueprint Workspace by clicking (|image1|) icon located on the left tool ribbon.  This will open the Blueprint Workspace where self-authored blueprints are staged for editing, publishing, and/or launching as Applications.  When the Blueprint grid appears, click the **Upload Blueprint** button located along the top of the Blueprint grid.
+Click **Upload Blueprint**.
 
 .. figure:: https://s3.amazonaws.com//s3.nutanixworkshops.com/calm/lab3/image2.png
 
-Navigate to the blueprint file (i.e. *mssql2014.json*) recently downloaded and select it by clicking on the file.
+Select the downloaded MSSQL Blueprint (e.g. **windowsMSSQL2014.json**) and click **Open**.
 
-A modal dialog will appear prompting for a name and project when saving. Complete the fileds as shown below and click **upload**. This will save the blueprint to the workspace.
+Fill out the following fields and click **Upload**:
 
-- **Name:** mssql2014
-- **Project:** Calm
+- **Blueprint Name** - mssql2014-*<INITIALS>*
+- **Project** - Calm
 
-.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/calm_mssql/image1.png
+Updating the Credential
+***********************
+Blueprints are exported as clear text and subsequently do not retain credential details, as this information could be used maliciously.
 
-Assign Credential
-=================
-Since Blureprints are exported as clear text, they do not retain credential information that could potentially be used maliciously.  You'll be required to set the **Credentials**.  set the creddentials as follows:
+Click **Credentials** and select **WINDOWS (Default)**.
 
-.. code-block:: bash
+Fill out the following fields and click **Back**:
 
-  Credential Name : WINDOWS
-  Username        : ntnxlab.local\administrator
-  Secrete         : password
-  Password        : nutanix/4u
-  
-Once complete, click the **Back** button located in the upper right, and then click **Save** along the top menu-bar.
+- **Username** - ntnxlab.local\\administrator
+- **Secret** - Password
+- **Password** - nutanix/4u
 
-Configure Blueprint Variables
-=============================
-The **mssql2014** blueprint uses service variables to configure pre and post runtime behavior.  The blueprint configuration variables can be accessed by clicking on the **Service** tab of blueprint located to the right of blueprint workspace.
+Click **Save** to save the updated Blueprint.
+
+Configuring Service Variables
+*****************************
+The Blueprint uses the following Service Variables to configure pre-runtime and post-runtime behavior:
 
 +-----------------------+----------------------------------------------------------------------+
-|**Variable**           |**Description**                                                       |
+|**Variable Name**      |**Description**                                                       |
 +-----------------------+----------------------------------------------------------------------+
 |install_location       |A location directive (internal/external) definng if the image is      |
 |                       |accessible internally (fiel share), or externally                     |
@@ -84,175 +80,158 @@ The **mssql2014** blueprint uses service variables to configure pre and post run
 |mapped_drive           |The logical drive designator if using a mapped location/drive.        |
 +-----------------------+----------------------------------------------------------------------+
 
-The following Blueprint variables should be configured as follows: 
+Select the **MSSQL** Service from your **Workspace**.
 
-.. code-block:: bash
+In the **Configuration Pane**, select the **Service** tab.
 
-  install_location     : internal
-  file_share_user      : administrator
-  file_share_password  : nutanix/4u
-  file_server_ip       : 10.21.66.59
-  file_share_name      : sql
-  sql_iso_path         : SQLServer2014SP2-FullSlipstream-x64-ENU.iso
-  mapped_drive         : z
+Verify the Variables match the following values and click **Save**:
 
-Once complete, click **Save** located along the top menu-bar.
+- **install_location** - internal
+- **file_share_user** - administrator
+- **file_share_password** - nutanix/4u
+- **file_server_ip** - 10.21.66.59
+- **file_share_name** - sql
+- **sql_iso_path** - SQLServer2014SP2-FullSlipstream-x64-ENU.iso
+- **mapped_drive** - z
 
-VM Creation
-===========
-A Windows Server VM is required to host the MS SQL 2014 Database instance. VM settings and configurations can be accomplished by clicking on the VM tab of the service.  Set the following *Substrate Name*, *Cloud*, and *OS* fields using the following values:
+Configuring the VM
+******************
 
-.. code-block:: bash
+Select the **MSSQL** Service from your **Workspace**.
 
-  Name        : MSSQL2014
-  Cloud       : Nutanix
-  OS          : Windows
-  
-  
-.. note:: When deploying or working with Windows VMs deployed by Calm, you'll be required to set the operating system to Windows, as opposed to Linux (default) within the blueprint. 
+In the **Configuration Pane**, select the **VM** tab.
 
-VDISK Settings
-===============
-Add a **VDISK** by clicking on the **(+)** to expand the **VDISKS** configuration window. Configure a **VDISK** using the following parameters:
+Verify the following fields:
 
-.. code-block:: bash
+- **Service Name** - MSSQL
+- **Name** - MSSQL2014
+- **Cloud** - Nutanix
+- **OS** - Windows
+- **VM Name** - @@{calm_application_name}@@
 
-  Disk Type   : DISK
-  Device Bus  : SCSI
-  Size        : 100GB
+Fill out the following fields:
 
-Guest VM Image Settings
-=======================
-Add an **Image** by clicking on the **(+)** to expand the **IMAGES** configuration window.  Configure the **Guest VM** using the following parameters:
+- Select :fa:`plus-circle` under **vDisks**
 
-.. code-block:: bash
+  - **Device Type** - Disk
+  - **Device** Bus - SCSI
+  - **Size (GiB)** - 100
 
-  VM Name     : @@{calm_application_name}@@
-  Image       : Windows2012
-  Disk Type   : DISK
-  Device Bus  : SCSI
-  vCPU        : 2
-  Core/vCPU   : 2
-  Memory      : 4 GB
+- **vCPUs** - 2
+- **Cores per vCPU** - 2
+- **Memory (GiB)** - 4
+- Select :fa:`plus-circle` under **Images**
 
-Guest Customization
-===================
-The **mssql2014** blueprint uses **Guest Custiomizations** to configure runtime behavior.  
+  - **Image** - Windows2012
+  - **Device Type** - Disk
+  - **Device** Bus - SCSI
+  - Select **Bootable**
 
-Guest Customization can be accessed as part of the **VM Configuration**:
+- Select **Guest Customization**
 
-- Click the **Guest Customization** Check-Box just below the Guest VM settings to access the script window.
-- Select the **Sysprep** radio button.
-- Copy the contents from unattend.xml_ and paste it to the **Script** window.
+  - **Type** - Sysprep
+  - **Script** - Copy the contents of unattend.xml_ and paste into the **Script** field.
 
-Once complete, click **Save** located along the top menu-bar.
+  .. note:: The sysprep unattend.xml script automates the sysprep process and automatically joins the VM to the ntnxlab.local domain.
 
-Guest VM Network Settings
-==========================
-Verify the Guest VM **NETWORK ADAPTERS (NICS)** settings are as follows:
+- Select :fa:`plus-circle` under **Network Adapters (NICs)**
 
-.. code-block:: bash
+  - **NIC** - Secondary
+- **Connection**
 
-  NIC  : secondary
+  - **Crendential** - WINDOWS
+  - **Address** - @@{platform.status.resources.nic_list[0].ip_endpoint_list[0].ip}@@
+  - **Connection Type** - Windows (PowerShell)
+  - **Connection Port** - 5985
+  - **Timeout (secs)** - 600
 
-Guest VM Connection Settings
-=============================
-Verify the Guest VM **CONNECTION** settings are as follows:
+Click **Save**.
 
-.. code-block:: bash
+Scroll to the top of the **Configuration Panel**, click **Package**.
 
-  Check log-in upon create   : checked
-  Credential                 : WINDOWS
-  Address                    : @@{platform.status.resources.nic_list[0].ip_endpoint_list[0].ip}@@
-  Connection Type            : Windows (Powershell)
-  Connection Port            : 5985
-  Timeout (secs)             : 600
-  
-Click **Save** located along the top menu-bar If there were any changes.
+Configuring the Package
+***********************
 
-Package Settings
-=============================
-Verify the Service **Package** settings are as follows:
+Scroll to the top of the **Configuration Panel**, and select the **Package** tab.
 
-.. code-block:: bash
+Verify the following fields:
 
-  Name        : MSSQLPackage
-  
-Verify **INSTALL** settings:
+- **Name** - MSSQLPackage
+- **Install Script Type** - Shell
+- **Install Credential** - WINDOWS
+- **Install Script** - ``Enable-WSManCredSSP -Role Server -Force``
 
-.. code-block:: bash
+If any changes were required, click **Save**.
 
-  Script Type : Shell
-  Credential  : WINDOWS
-  Script      : Enable-WSManCredSSP -Role Server -Force
+Exploring the Create Action
+***************************
 
-Click **Save** located along the top menu-bar If there were any changes.
+In addition to the Package scripts used to install or uninstall a Service, individual Services within a Calm Blueprint can contain Actions consisting of multiple Tasks and Service Actions.
 
-Enable CredSSP
-==============
+Tasks allow you to set variable values, execute shell scripts on a remote VM, or execute an EScript. EScripts are specialized Python scripts that run locally within Calm and are helpful for use cases such as making REST calls directly to a web service.
 
-.. note:: The instructions in this section are applicable to the karan Guest VM and required for SQL Server deployments.
+Service Actions allow you to Start, Stop, or Delete the VM associated with a Service. These Actions are typically used in lifecycle operations such as scaling up or scaling down an application.
 
-To Enable CredSSP on the Karan Guest VM, please follow steps below:
+In **Application Overview**, select **Services > MSSQL > Create**.
 
-Using a *remote-desktop* session, or *console* connection to the Karan Guest VM open a *PowerShell-Command* window and run the following command to enable CredSSP as a client role and allow Karan Guest VM to delegate credentials to all computers (Wild card mask "*"):
+Select the **InitializeDisk** task and review the PowerShell script in the **Configuration Pane**.
 
-.. code-block:: powershell
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/calm_mssql/image3.png
 
-  PS C:>\ Enable-WSManCredSSP -Role Client -DelegateComputer *
-  
-Open a *Command-Prompt* window and run the following command:
+Select the **InstallMSSQL** task and review the PowerShell script in the **Configuration Pane**.
 
-.. code-block:: bash
+Configuring Priveleges
+**********************
 
-  C:>\ gpedit.msc
-   
-In the group policy editor:
+.. note::
 
-- Navigate to **Computer-configuration -> administrative templates -> system -> credential-delegation**.
-- Double click on **Allow Delgating Fresh Credentials with NTLM-only server authentication**.
-- Select the **Enable** radio button.
-- Click on the **show** button.
-- In the value field add  **WSMAN/***. This allows delegate fresh credentials to **WSMAN** running in any remote computer
-  
-Privileges:
-============
+  To successfully perform a remote SQL Server installation the user account used to run the Karan Service (e.g. NTNXLAB\\Administrator) must be granted SE_INCREASE_QUOTA_NAME and SE_ASSIGNPRIMARYTOKEN_NAME permissions on the Karan VM.
 
-.. note:: The instructions in this section are applicable to the karan Guest VM and required for SQL Server deployments.
+  In a production environment with multiple Karan VMs these permissions could be automatically configured via Domain Group Policy.
 
-Using a *remote-desktop* session, or *console* connection to the Karan Guest VM, follow the steps below to assign the correct privileges for user: *Administrator*:
+From the **Karan** VM console, open **Control Panel > Administrative Tools > Local Security Policy**.
 
-- Idenitfy the user account that the Karan service is running as.  In this lab the user account is: **Administrator**. 
-- From the Start menu, click on **Administrative Tools**, and then click **Local Security Policy**.
-- In the **Local Security Settings** dialog box, double-click **Local Policies**, and then double-click **User Rights Assignment**.
-- In the details pane, double-click **Adjust memory quotas for a process**. This sets the **SE_INCREASE_QUOTA_NAME** user right.
-- Click **Add User or Group**, and, in the **Enter the object names to select** box, type the user **Administrator** and then click **OK**.
-- Click OK again, and then, in the details pane, double-click **Replace a process level token**. This sets the  **SE_ASSIGNPRIMARYTOKEN_NAME** user right.
-- Click **Add User or Group**, and, in the **Enter the object names to select** box, type the user **Administrator** and then click **OK**.
-- Close **Local Security Policy** and **Administrative Tools** windows.
-- Restart the Karan service.
+Navigate to **Local Policies > User Rights Assignment**.
 
-.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/karan/image16.png
+Double-click the **Adjust memory quotas for a process** Policy.
 
-Launch Blueprint
-================
-Once the *mssql2014* blueprint and Karan Guest VM settings have been successfully configured and saved, click the (|image5|) button to **lanuch** the Blueprint.  Name the application with *mssql2014*.
+Click **Add User or Group**.
 
-.. note:: When performing deployments on a community/team cluster, append your initials to the deployment name for traceability.
+Specify **Administrator** in the **Enter the object names to select** field, and click **OK > OK**.
 
-.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/calm_mssql/image2.png
+Double-click the **Replace a process level token** Policy.
 
-Click **Create** to launch the application.
+Click **Add User or Group**.
 
-Once the application has been launched, the Application Management Dialog will appear showing the state of the Application.  Click the *Audit* button in the tool-bar located along the top of the Application Management Dialog to monitor or audit the provisioning progress of the application.
+Specify **Administrator** in the **Enter the object names to select** field, and click **OK > OK**.
+
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/calm_mssql/image4.png
+
+Open **Control Panel > Administrative Tools > Services**. Select the **karan_1** service and click **Restart**.
+
+Launching the Blueprint
+***********************
+
+From the toolbar at the top of the Blueprint Editor, click **Launch**.
+
+In the **Name of the Application** field, specify a unique name including your initials (e.g. Calm-MSSQL-*<INITIALS>*-1).
+
+Click **Create**.
+
+You will be taken directly to the **Applications** page to monitor the provisioning of your Blueprint.
+
+Select **Audit > Create** to view the progress of your application. Once available, select **InstallMSSQL** to view the real time output of the installation script.
+
+Note the status changes to **Running** after the Blueprint has been successfully provisioned.
 
 Takeaways
 ***********
-- Downloaded and Imported an existing Windows MSSQL blueprint ro the *Blueprint Workspace*.
-- Learned to set variables that change blueprint behavior to source imnages and define credentials.
-- Learned how to setup and configure a Karan proxy server for executing powershell to provision windows servers.
 
-.. _karan-setup: ../karan/karan_sa_setup.html
+- Blueprints can be exported as JSON files.
+- Blueprints can be easily shared without sharing sensitive data such as credentials and secrets.
+- Calm is capable of automating and orchestrating Windows workloads with PowerShell and uses Karan to satisfy Kerberos authentication requirements.
+- Tasks can be used to structure even complex workflows for workload automation.
+- Variables can be defined globally within a Blueprint or specific to a given Service.
 
 .. |image1| image:: https://s3.amazonaws.com/s3.nutanixworkshops.com/calm/lab3/image1.png
 .. |image5| image:: https://s3.amazonaws.com/s3.nutanixworkshops.com/calm/lab3/image5.png

--- a/deploy/config.sh
+++ b/deploy/config.sh
@@ -144,7 +144,7 @@ my_log "Importing X-Ray image"
 acli image.create XRay container="${MY_IMG_CONTAINER_NAME}" image_type=kDiskImage source_url=http://10.21.64.50/images/xray-2.3.qcow2 wait=true
 
 my_log "Importing HYCU image"
-acli image.create HYCU container="${MY_IMG_CONTAINER_NAME}" image_type=kDiskImage source_url=http://10.21.64.50/images/hycu-2.0.1-90.qcow2 wait=true
+acli image.create HYCU container="${MY_IMG_CONTAINER_NAME}" image_type=kDiskImage source_url=http://10.21.64.50/images/hycu-2.0.1-105.qcow2 wait=true
 
 my_log "Importing Xtract VM image"
 acli image.create Xtract-VM container="${MY_IMG_CONTAINER_NAME}" image_type=kDiskImage source_url=http://10.21.64.50/images/xtract-vm-1.1.3.qcow2 wait=true

--- a/index.rst
+++ b/index.rst
@@ -73,7 +73,11 @@ Following presentations on Tuesday, you will have approximately 4 hours to compl
 
 Beginning on Wednesday you will be provided with a customer challenge. Your goal is to build and propose a solution using Nutanix and optional 3rd party technologies. The **Optional Labs** provide step by step guides for additional technologies you may find useful for your proposed solution. Bonus points can be earned by incorporating additional technologies (Chef, Puppet, Jenkins, Nagios, etc.) not covered in **Optional Labs**.
 
-Each team has been provided a four node cluster running AHV and AOS 5.5.1. **Upon Electing a Team Lead and Consulting Your Team Coach Please Exam Your Cluster.** Each cluster has been pre-staged with the following:
+Each team has been provided a four node cluster running AHV and AOS 5.5.1. It is **HIGHLY RECOMMENDED** that you access the environment via a `Citrix XenDesktop <https://citrixready.nutanix.com>`_ session.
+
+**Do Not Start Labs Before Electing a Team Lead and Consulting Your Team Coach**
+
+Each cluster has been pre-staged with the following:
 
 .. **Challenge**
 
@@ -101,16 +105,15 @@ Each team has been provided a four node cluster running AHV and AOS 5.5.1. **Upo
 **Credentials**
 
 - **Prism Username:** admin **Password:** techX2018!
+- **Prism Central Username:** admin **Password:** techX2018!
 - **CVM Username:** nutanix **Password:** techX2018!
+- **PC VM Username:** nutanix **Password:** nutanix/4u
 - **Domain Username** NTNXLAB\\Administrator **Password:** nutanix/4u
 
 **Networks**
 
-- `IP information for your team <https://drive.google.com/drive/folders/1-8vVrC7Ad9uFeWnY1LcaffQQEoD-Eris>`_
 - **Primary** Network - 10.21.XX.1/25 - IPAM DHCP Pool 10.21.XX.50-10.21.XX.124
 - **Secondary** Network - 10.21.XX.129/25 - IPAM DHCP Pool 10.21.XX.132-10.21.XX.253
 - **Link-Local** Network - **DO NOT ENABLE IPAM**
 
-.. note::
-
-  Due to resource limitations, many labs are designed to be completed as a group. The Overview section of each lab will indicate whether the lab should be completed once per group/cluster or if it can be performed individually. **Do Not Start Labs Before Electing a Team Lead and Consulting Your Team Coach**.
+`Click here to view details of your team cluster assignment. <https://drive.google.com/file/d/1MjlH9s4UjyhDXkNABeRJ49UQdG6YdRhN/view?usp=sharing>`_

--- a/index.rst
+++ b/index.rst
@@ -26,9 +26,9 @@
   :name: _opt-labs
   :hidden:
 
-  citrix/index
-  .. karan/karan_sa_setup
+  karan/karan_sa_setup
   calm_mssql/calm_mssql
+  citrix/index
   git/gitlab
   hycu/index
   docker/calm_workshop_lab7_docker

--- a/karan/karan_sa_setup.rst
+++ b/karan/karan_sa_setup.rst
@@ -13,6 +13,8 @@ Overview
 
   Estimated time to complete: **30 MINUTES**
 
+  **This lab should be completed as a group.**
+
 In this exercise you will deploy the Karan Service to a Windows Server 2012 R2 VM. Karan is a scale out service used by Calm to orchestrate Windows VMs. Karan is responsible for proxying remote PowerShell commands from Calm Blueprints to Windows VMs.
 
 Deploying Karan VM
@@ -22,7 +24,7 @@ In **Prism Central > Explore > VMs**, click **Create VM**.
 
 Fill out the following fields and click **Save**:
 
-- **Name** - Karan-*<INITIALS>*
+- **Name** - Karan
 - **Description** - Karan Server
 - **vCPU(s)** - 2
 - **Number of Cores per vCPU** - 2
@@ -40,14 +42,12 @@ Fill out the following fields and click **Save**:
 - Select **Type or Paste Script**
 
 .. literalinclude:: unattend.xml
-   :caption: Karan-<INITIALS> Unattend.xml Custom Script
+   :caption: Karan Unattend.xml Custom Script
    :language: xml
 
 .. note::
 
-  **IMPORTANT!** Replace <ComputerName>\*</ComputerName> with your desired hostname (e.g. <ComputerName>Karan-DJP</ComputerName>) prior to clicking **Save**.
-
-  The Unattend script will update the hostname, join the NTNXLAB.local domain, and disable the Windows Firewall.
+  The Unattend script will change the hostname to **Karan**, join the **NTNXLAB.local** domain, and disable the Windows Firewall.
 
 Verify the VM has the expected hostname and has been joined to the NTNXLAB.local domain.
 

--- a/karan/karan_sa_setup.rst
+++ b/karan/karan_sa_setup.rst
@@ -53,11 +53,12 @@ Verify the VM has the expected hostname and has been joined to the NTNXLAB.local
 
 .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/karan/image15.png
 
-Open **Powershell** and execute the following commands:
+Open **PowerShell** and execute the following commands:
 
 .. code-block:: posh
+  :emphasize-lines: 1,3,5
 
-  # Enables the VM to receive Windows Powershell remote commands sent using WS-Management. Enabled by default in Windows Server 2012 R2 and later.
+  # Enables the VM to receive Windows PowerShell remote commands sent using WS-Management. Enabled by default in Windows Server 2012 R2 and later.
   Enable-PSRemoting -Force
   # Default execution policy in Windows Server 2012 R2 and later. Requires a digital signature from a trusted publisher on scripts and configuration files that are downloaded from the Internet. Does not require digital signatures on scripts that you have written on the local computer.
   Set-ExecutionPolicy RemoteSigned -Force
@@ -117,9 +118,10 @@ Enabling CredSSP
 
 CredSSP authentication allows user credentials to be passed to a remote computer to be authenticated. This type of authentication is designed for commands that create a remote session from another remote session. This allows Calm to validate credentials of a target VM through the Karan Service.
 
-Open **Powershell** and execute the following commands:
+Open **PowerShell** and execute the following commands:
 
 .. code-block:: posh
+  :emphasize-lines: 1,3
 
   # Enables CredSSP as a client role and allows Karan VM to delegate credentials to all computers
   Enable-WSManCredSSP -Role Client -DelegateComputer * -Force
@@ -142,5 +144,6 @@ Click **OK > OK**.
 
 Takeaways
 *********
-- Calm can orchestrate Windows workloads via Powershell scripts distributed with the Karan Service.
+- Calm can orchestrate Windows workloads via PowerShell scripts distributed with the Karan Service.
 - Multiple Karan servers can be deployed in the same environment to meet the needs of an increasing number of Windows VMs.
+PowerShell

--- a/karan/karan_sa_setup.rst
+++ b/karan/karan_sa_setup.rst
@@ -1,140 +1,146 @@
-***********************
-Karan Configuration SA
-***********************
- 
- 
+.. _karan_lab:
+
+******************
+Calm Karan Service
+******************
+
 Overview
 *********
 
-.. note:: Estimated time to complete: **30 MINUTES**
- 
-In this lab, participants will deploy a Windows 2012 Server Guest VM and provision it with Karan.  Karan is used as a proxy for Calm automation.
- 
-Karan is a component that allows the Calm services to run PowerShell scripts on Windows virtual machines. Think of Karan as a “translation” layer between Calm and the Windows VMs.
- 
- 
-Configure Karan
+.. note::
+
+  This lab should be completed **BEFORE** the :ref:`calm_mssql_lab` lab.
+
+  Estimated time to complete: **30 MINUTES**
+
+In this exercise you will deploy the Karan Service to a Windows Server 2012 R2 VM. Karan is a scale out service used by Calm to orchestrate Windows VMs. Karan is responsible for proxying remote PowerShell commands from Calm Blueprints to Windows VMs.
+
+Deploying Karan VM
 ******************
-Using Windows with Calm
- 
-In order for Calm to work with Windows virtual machines, an additional step is required. After deploying Prism Central and completing the configuration of Calm itself, an additional virtual machine must be deployed that runs the ‘Karan’ service.
- 
-.. note:: Check to make sure that Prism Central has already been configured and Calm has been setup before proceeding.
- 
-Before you begin
-================
-- The Karan service will be installed on Windows Server 2012 R2.
-- Your Windows Server should always be up and running to support Calm automation for windows.
-- Powershell 3.0 or onwards should be installed on the Karan server.
-- .Net framework 4.0 or 4.5 should be installed on the Karan server.
- 
-Deploying Karan Guest VM
-=========================
-Create a Windows Virtual Machine running Windows 2012 R2 using the following parameters:
 
-.. code-block:: bash
+In **Prism Central > Explore > VMs**, click **Create VM**.
 
-  vCPU       : 2x
-  Cores      : 2x (2x cores/vCPU)
-  Mem        : 2GB
-  Storage    : 40GB (default-container)
-  Network    : Secondary
-  Image      : Windows2012 (This is a Server 2012 QCOW image)
-  Image Type : Disk
-  Bus        : SCSI
-  
-Power the Karan Guest VM on.
+Fill out the following fields and click **Save**:
 
-Login to the Karan Guest VM via *Launch Console* or *Remote Desktop*.  Upon successful log-in:
+- **Name** - Karan-*<INITIALS>*
+- **Description** - Karan Server
+- **vCPU(s)** - 2
+- **Number of Cores per vCPU** - 2
+- **Memory** - 4 GiB
+- Select **+ Add New Disk**
 
-- **Change** the Computer Name to **KARAN**
-- **Add** the Karan Guest VM to the **ntnxlab.local** domain.  
-- Reboot the server.
+  - **Operation** - Clone from Image Service
+  - **Image** - Windows2012
+  - Select **Add**
+- Select **Add New NIC**
+
+  - **VLAN Name** - Primary
+  - Select **Add**
+- Select **Custom Script**
+- Select **Type or Paste Script**
+
+.. literalinclude:: unattend.xml
+   :caption: Karan-<INITIALS> Unattend.xml Custom Script
+   :language: xml
+
+.. note::
+
+  **IMPORTANT!** Replace <ComputerName>\*</ComputerName> with your desired hostname (e.g. <ComputerName>Karan-DJP</ComputerName>) prior to clicking **Save**.
+
+  The Unattend script will update the hostname, join the NTNXLAB.local domain, and disable the Windows Firewall.
+
+Verify the VM has the expected hostname and has been joined to the NTNXLAB.local domain.
 
 .. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/karan/image15.png
 
-- Disable the Karan Guest VM firewall.
+Open **Powershell** and execute the following commands:
 
-After the Karan Guest VM has completed reboot, login via *Launch Console* or *Remote Desktop*.  Upon successful log-in open a *PowerShell-Command-Window*.
+.. code-block:: posh
 
-.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/karan/image17.png
-
-Within the  *PowerShell-Command-Window* run the following command to enable PowerShell remote execution - answer **'Y'** when prompted.
- 
-.. code-block:: PowerShell
- 
-    PS C:\> enable-psremoting
-   
-Within the  *PowerShell-Command-Window* run the following command to set the PowerShell Execution Policy - answer **'Y'** when prompted.
- 
-.. code-block:: PowerShell
- 
-    PS C:\> set-executionpolicy remotesigned
-   
-Within the *powershell-command-window* run the following command to set all target machines as trusted machines on the Karan host - answer **'Y'** when prompted.
- 
-.. code-block:: PowerShell
- 
-    PS C:\> set-item wsman:\localhost\Client\TrustedHosts -Value *
+  # Enables the VM to receive Windows Powershell remote commands sent using WS-Management. Enabled by default in Windows Server 2012 R2 and later.
+  Enable-PSRemoting -Force
+  # Default execution policy in Windows Server 2012 R2 and later. Requires a digital signature from a trusted publisher on scripts and configuration files that are downloaded from the Internet. Does not require digital signatures on scripts that you have written on the local computer.
+  Set-ExecutionPolicy RemoteSigned -Force
+  # Adds all potential target machines (Windows VMs being orchestrated by Calm) as trusted hosts
+  Set-Item WSMan:\localhost\Client\TrustedHosts -Value * -Force
 
 Installing Karan
-=================
+****************
 
-.. note:: The karan installer is very large and might be best to use a VDI connection to download the file from http://10.21.64.50/images/Karan-1.6.0.0.exe and then map the download to you Guest VM.
+.. note:: The Karan Service is supported on both Windows Server 2012 R2 and Windows Server 2016 and requires Poweshell 3.0+ and either .NET Framework 4.0 or .NET Framework 4.5.
 
-If you download the karan-installer_ locally to your Mac, you'll need to establish a cifs connection
+From your **Karan** VM console, download the `Karan installer <http://download.nutanix.com/calm/Karan/1.6.0/Karan-1.6.0.0.exe>`_.
 
-.. code-block:: bash
+.. note:: The provided link to the Karan 1.6.0.0 installer is current as of March 2018.
 
-  % cifs://<karan-guest-vm-ipaddress>/c$ 
-  
-.. note:: The karan.exe link referenced was sourced as of January 2018.
+Launch the Karan installer as an Administrator.
 
-Upload the karan installer to the Karan Guest VM and launch the Karan installer...  When prompted, populate the fields as follows:
+Click **Install > Next**.
 
-- Select HTTP.  DO NOT SELECT HTTPS (Default)!!
-- Set the port to 8090 (note that this must not be changed and port 8090 must be allowed through the Windows firewall on both host and client VMs)
-- Set the number of Karan instances to 1 (typical for demo/lab environments)
-- Enter the IP Address of the Karan instance. The IP address must be accessible from the Calm/Prism Central VM!
-- Set the gateway UUID to:
- 
-.. code-block:: bash
- 
-    2067b70d-bd3f-4b3d-9d82-3add93f30a0a
- 
-- Enter the Prism Central VM IP Address and the port of the Epsilon Service as follows:
- 
-.. code-block:: bash
- 
-    http://<prism_central_ip_address>:8090
- 
-.. note:: Be sure to specify the port 8090, as per the example above in order to connect to the Epsilon Service running on the PC VM!
- 
-- Click Next
-- Specify the account information:
+Fill out the following fields and click **Next**:
 
-.. code-block:: bash
-  
-  logon account: administrator
-  password: nutanix/4u
-  
-- Complete the wizard until Karan installer has successfully completed the installation.
-- Using a command-prompt on the Karan Guest VM start the Windows Services as follows:
- 
-.. code-block:: bash
- 
-  c:\> services.msc
+- Select **HTTP** (Do **NOT** select **HTTPS**)
+- **Port** - 8090
 
-- From the Windows Services start the Karan service.  The service should start.  If the service fails to start, review the previous steps and contact your facilitator.
+.. note:: If a firewall is enabled on either the Karan or target VMs, TCP port 8090 must be allowed.
 
-.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/karan/image16.png
+- **Service Count** - 1
+- **Hostname** - *<Karan VM IP Address>*
+- **Gateway UUID** - 2067b70d-bd3f-4b3d-9d82-3add93f30a0a
+- **Epsilon Address** - http://*<Prism Central IP Address>*:8090
 
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/karan/karan2.png
 
+.. note::
+
+  Do **NOT** click **Check Epsilon IP**.
+
+Fill out the following fields and click **Next**:
+
+- **Logon Account** - NTNXLAB\\Administrator
+- **Password** - nutanix/4u
+
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/karan/karan3.png
+
+Click **Install**.
+
+After installation has completed, click **Finish**.
+
+Open **Control Panel > Administrative Tools > Services**. Select the **karan_1** service and click **Start**.
+
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/karan/karan4.png
+
+.. note:: If the service fails to start, uninstall Karan and closely follow the installation steps. Common mistakes include selecting HTTPS or providing an incorrect Gateway UUID.
+
+Enabling CredSSP
+****************
+
+CredSSP authentication allows user credentials to be passed to a remote computer to be authenticated. This type of authentication is designed for commands that create a remote session from another remote session. This allows Calm to validate credentials of a target VM through the Karan Service.
+
+Open **Powershell** and execute the following commands:
+
+.. code-block:: posh
+
+  # Enables CredSSP as a client role and allows Karan VM to delegate credentials to all computers
+  Enable-WSManCredSSP -Role Client -DelegateComputer * -Force
+  # Opens Local Group Policy Editor
+  gpedit
+
+In the **Local Group Policy Editor**, open **Computer Configuration > Administrative Templates > System > Credentials Delegation**.
+
+Double-click **Allow delegating fresh credentials with NTML-only server authentication**.
+
+Select **Enabled**.
+
+Click **Show** and specify **WSMAN/*** in the **Value** field.
+
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/karan/karan5.png
+
+Click **OK > OK**.
+
+.. figure:: https://s3.us-east-2.amazonaws.com/s3.nutanixtechsummit.com/karan/karan6.png
 
 Takeaways
 *********
-- Congratulations you have successfully configured a guest VM and Karan!
-
-.. _karan-installer: http://10.21.64.50/images/Karan-1.6.0.0.exe
-
- 
+- Calm can orchestrate Windows workloads via Powershell scripts distributed with the Karan Service.
+- Multiple Karan servers can be deployed in the same environment to meet the needs of an increasing number of Windows VMs.

--- a/karan/unattend.xml
+++ b/karan/unattend.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+	<settings pass="oobeSystem">
+		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+			<OOBE>
+				<HideEULAPage>true</HideEULAPage>
+			</OOBE>
+			<UserAccounts>
+				<AdministratorPassword>
+					<Value>nutanix/4u</Value>
+					<PlainText>true</PlainText>
+				</AdministratorPassword>
+			</UserAccounts>
+			<AutoLogon>
+				<Password>
+					<Value>nutanix/4u</Value>
+					<PlainText>true</PlainText>
+				</Password>
+				<Enabled>true</Enabled>
+				<Username>NTNXLAB\Administrator</Username>
+			</AutoLogon>
+		</component>
+		<component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+			<InputLocale>en-US</InputLocale>
+			<SystemLocale>en-US</SystemLocale>
+			<UILanguage>en-US</UILanguage>
+			<UserLocale>en-US</UserLocale>
+		</component>
+	</settings>
+	<settings pass="specialize">
+		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+			<ComputerName>*</ComputerName>
+			<RegisteredOrganization>Nutanix</RegisteredOrganization>
+			<RegisteredOwner>Nutanix</RegisteredOwner>
+			<TimeZone>Pacific Standard Time</TimeZone>
+			<ProductKey>W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9</ProductKey>
+		</component>
+		<component name="Microsoft-Windows-UnattendedJoin" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+			<Identification>
+				<UnsecureJoin>false</UnsecureJoin>
+				<Credentials>
+					<Domain>NTNXLAB.local</Domain>
+					<Password>nutanix/4u</Password>
+					<Username>administrator</Username>
+				</Credentials>
+				<JoinDomain>NTNXLAB.local</JoinDomain>
+			</Identification>
+		</component>
+		<component name="Networking-MPSSVC-Svc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DomainProfile_EnableFirewall>false</DomainProfile_EnableFirewall>
+            <PrivateProfile_EnableFirewall>false</PrivateProfile_EnableFirewall>
+            <PublicProfile_EnableFirewall>false</PublicProfile_EnableFirewall>
+    </component>
+	</settings>
+</unattend>

--- a/karan/unattend.xml
+++ b/karan/unattend.xml
@@ -29,7 +29,7 @@
 	</settings>
 	<settings pass="specialize">
 		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<ComputerName>*</ComputerName>
+			<ComputerName>Karan</ComputerName>
 			<RegisteredOrganization>Nutanix</RegisteredOrganization>
 			<RegisteredOwner>Nutanix</RegisteredOwner>
 			<TimeZone>Pacific Standard Time</TimeZone>
@@ -47,9 +47,9 @@
 			</Identification>
 		</component>
 		<component name="Networking-MPSSVC-Svc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <DomainProfile_EnableFirewall>false</DomainProfile_EnableFirewall>
-            <PrivateProfile_EnableFirewall>false</PrivateProfile_EnableFirewall>
-            <PublicProfile_EnableFirewall>false</PublicProfile_EnableFirewall>
+	    <DomainProfile_EnableFirewall>false</DomainProfile_EnableFirewall>
+	    <PrivateProfile_EnableFirewall>false</PrivateProfile_EnableFirewall>
+	    <PublicProfile_EnableFirewall>false</PublicProfile_EnableFirewall>
     </component>
 	</settings>
 </unattend>


### PR DESCRIPTION
Formatting edits for Karan and MSSQL lab. 

Added the Karan guide to the TOC. Moved MSSQL and Karan to optional labs for TS EMEA.

Added an unattend file for the Karan setup to smooth out the initial VM deployment. 

Pulled the Enable CredSSP steps into the Karan lab as it appears from the product documentation that this is a common requirement for Windows workloads. Left the SE_INCREASE_QUOTA_NAME and SE_ASSIGNPRIMARYTOKEN_NAME permissions in the MSSQL lab after discussion with MJ as this appears to be unique to the SQL Blueprint.

Added short section to MSSQL lab to dive deeper into the Blueprint so users know where the actual SQL deployment scripts live within the Blueprint.

Updated the takeaways with Chris Brown's suggestions.